### PR TITLE
carthage 集成方式，工程缺少 Bundle Version，提交Appstore审核出错 ERROR ITMS-90056

### DIFF
--- a/Schedule.xcodeproj/project.pbxproj
+++ b/Schedule.xcodeproj/project.pbxproj
@@ -402,6 +402,7 @@
 		OBJ_46 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -431,6 +432,7 @@
 		OBJ_47 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
经过多次测试，在使用 carthage 集成方式，提交审核的确会出现上述问题，最后发现问题是因为：该工程缺少 build 对应的 值，现在已经加上，可解决上述问题